### PR TITLE
Add Streamlit interface for RAG chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ This repository contains a simple RAG-based chatbot built with Python and the Op
    ```bash
    export OPENAI_API_KEY=your_key
    ```
-3. Start the chatbot:
+3. Launch the Streamlit app:
    ```bash
-   python rag_chatbot.py
+   streamlit run streamlit_app.py
    ```
 
-The bot stores conversation history in `chat_history.json` and reuses previous
-answers when similar questions are asked again.
+The app will open in your browser and store conversation history in
+`chat_history.json`, reusing previous answers when similar questions are asked
+again.
+
+> The original terminal chatbot can still be started with
+> `python rag_chatbot.py` if desired.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 openai
 numpy
+streamlit

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,39 @@
+import streamlit as st
+from rag_chatbot import (
+    load_history,
+    save_history,
+    search_similar,
+    generate_answer,
+    THRESHOLD,
+)
+
+st.title("RAG Chatbot")
+
+if "history" not in st.session_state:
+    st.session_state.history = load_history()
+
+# Display previous conversation
+for item in st.session_state.history:
+    with st.chat_message("user"):
+        st.write(item["question"])
+    with st.chat_message("assistant"):
+        st.write(item["answer"])
+
+if question := st.chat_input("Ask something"):
+    with st.chat_message("user"):
+        st.write(question)
+    record, sim, q_emb = search_similar(question, st.session_state.history)
+    if record and sim >= THRESHOLD:
+        answer = record["answer"]
+        with st.chat_message("assistant"):
+            st.write(answer)
+    else:
+        answer = generate_answer(question)
+        with st.chat_message("assistant"):
+            st.write(answer)
+        st.session_state.history.append({
+            "question": question,
+            "answer": answer,
+            "embedding": q_emb,
+        })
+        save_history(st.session_state.history)


### PR DESCRIPTION
## Summary
- Switch from terminal-only interaction to a Streamlit-based web app
- Document Streamlit usage and keep terminal option
- Include Streamlit dependency

## Testing
- `python -m py_compile rag_chatbot.py streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6898a8fc1b748329a78612745c312e9d