### PR TITLE
Rename project to JsonRAGChatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# codex_project
+# JsonRAGChatbot
 
-This repository contains a simple RAG-based chatbot built with Python and the OpenAI API.
+JsonRAGChatbot is a simple RAG-based chatbot built with Python and the OpenAI API.
 
 ## Usage
 
@@ -22,4 +22,4 @@ The app will open in your browser and store conversation history in
 again.
 
 > The original terminal chatbot can still be started with
-> `python rag_chatbot.py` if desired.
+> `python json_rag_chatbot.py` if desired.

--- a/json_rag_chatbot.py
+++ b/json_rag_chatbot.py
@@ -1,4 +1,4 @@
-"""Simple RAG-based chatbot using OpenAI API.
+"""JsonRAGChatbot: simple RAG-based chatbot using OpenAI API.
 
 The bot keeps a local JSON history of past questions and answers along with
 embeddings. When a new question arrives, it searches the history for the most
@@ -9,7 +9,7 @@ OpenAI Chat API and the resulting answer is stored for future reuse.
 To run:
   1. Install dependencies: `pip install -r requirements.txt`
   2. Set your API key: `export OPENAI_API_KEY=...`
-  3. Start the bot: `python rag_chatbot.py`
+  3. Start the bot: `python json_rag_chatbot.py`
 
 The conversation history is stored in `chat_history.json` in the current
 working directory.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from rag_chatbot import (
+from json_rag_chatbot import (
     load_history,
     save_history,
     search_similar,
@@ -7,7 +7,7 @@ from rag_chatbot import (
     THRESHOLD,
 )
 
-st.title("RAG Chatbot")
+st.title("JsonRAGChatbot")
 
 if "history" not in st.session_state:
     st.session_state.history = load_history()


### PR DESCRIPTION
## Summary
- Rename project and module to JsonRAGChatbot
- Update README and Streamlit app title to reflect new name

## Testing
- `python -m py_compile json_rag_chatbot.py streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_689adc009ebc8329a77ba5d7c30473ad